### PR TITLE
Fix warning in case session data not exist

### DIFF
--- a/EventListener/DatatableListener.php
+++ b/EventListener/DatatableListener.php
@@ -68,10 +68,13 @@ class DatatableListener implements EventSubscriberInterface
         $pos_container = strripos($content, 'alidatatable-scripts');
         $sess_dta      = $session->get('datatable',array());
         $dta_script    = null;
-        array_walk($sess_dta, function(&$part, &$key) {
-            $part = trim(preg_replace('/\s\s+/', ' ', $part));
-        });
-        $dta_script = implode("\n", $sess_dta);
+        if ($sess_data)
+        {
+            array_walk($sess_dta, function(&$part, &$key) {
+                $part = trim(preg_replace('/\s\s+/', ' ', $part));
+            });
+            $dta_script = implode("\n", $sess_dta);
+        }
         $session->set('datatable', array());
         if (!$pos_container)
         {


### PR DESCRIPTION
Warning: array_walk() expects parameter 1 to be array, null given.
